### PR TITLE
docs: update GH Pages setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ A modern blogging website built with Create React App. It showcases curated rese
    ```bash
    npm run deploy
    ```
+   This publishes the `build` folder to the `gh-pages` branch. In your
+   repository settings, set GitHub Pages to serve from the `gh-pages` branch
+   so that `index.html` is used instead of the repository's `README.md`.
+
+   Ensure the `homepage` field in `package.json` points to
+   `https://yourusername.github.io/research-hub` (replace `yourusername` with
+   your GitHub username) so that asset paths resolve correctly.
 
 The site uses React, Tailwind CSS, and React Router. Blog data is defined in `src/pages/Home.jsx`.
 Tailwind CSS is compiled via PostCSS using the configuration in `postcss.config.js`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "A modern blogging site and research wiki to publish AI-driven insights and deep research outputs.",
-  "homepage": "https://yourusername.github.io",
+  "homepage": "https://yourusername.github.io/research-hub",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Summary
- explain how to deploy to GitHub Pages so the site serves the built `index.html`
- update `homepage` to include repository name

## Testing
- `npm test`
- :warning: `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885144969e8832399cc40d37069131e