### PR TITLE
Ensure homepage shows on gh-pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,9 +4,14 @@ import Footer from './components/Footer';
 import Home from './pages/Home';
 import About from './pages/About';
 
+// Determine the base path when the app is served from a subfolder (e.g. GitHub Pages)
+const basename = process.env.PUBLIC_URL
+  ? new URL(process.env.PUBLIC_URL, window.location.origin).pathname
+  : '/';
+
 export default function App() {
   return (
-    <Router>
+    <Router basename={basename}>
       <div className="min-h-screen flex flex-col">
         <Navbar />
         <main className="flex-1">


### PR DESCRIPTION
## Summary
- compute router basename from `PUBLIC_URL`
- pass basename to `BrowserRouter` so routes work on GitHub Pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885e8d51ca0832381874830c6297996